### PR TITLE
Add the option to flash system images directly

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -19,5 +19,5 @@ PRODUCT_MAKEFILES := \
 
 COMMON_LUNCH_CHOICES := \
 		omni_apollo-eng \
-		omni_appllo-user \
+		omni_apollo-user \
 		omni_apollo-userdebug

--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -17,5 +17,7 @@
 PRODUCT_MAKEFILES := \
     $(LOCAL_DIR)/omni_apollo.mk
 
-PRODUCT_USE_DYNAMIC_PARTITIONS := true
-COMMON_LUNCH_CHOICES := omni_apollo-eng
+COMMON_LUNCH_CHOICES := \
+		omni_apollo-eng \
+		omni_appllo-user \
+		omni_apollo-userdebug

--- a/device.mk
+++ b/device.mk
@@ -33,7 +33,7 @@ PRODUCT_PACKAGES_ENG += \
 # Stock flashable zips
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     ro.allow.mock.location=1
-    
+
 # Apex libraries
 PRODUCT_HOST_PACKAGES += \
     libandroidicu

--- a/recovery/root/system/etc/recovery.fstab
+++ b/recovery/root/system/etc/recovery.fstab
@@ -37,6 +37,7 @@
 #<src>                                                 <mnt_point>            <type>  <mnt_flags and options>                            <fs_mgr_flags>
 system                                                  /system                ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 system_ext                                              /system_ext            ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
+/dev/block/mapper/system                                /system_image          emmc    ro,barrier=1,discard                                 wait,logical,first_stage_mount,flashimg=1
 product                                                 /product               ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 vendor                                                  /vendor                ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 odm                                                     /odm                   ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount

--- a/recovery/root/system/etc/recovery.fstab
+++ b/recovery/root/system/etc/recovery.fstab
@@ -37,7 +37,7 @@
 #<src>                                                 <mnt_point>            <type>  <mnt_flags and options>                            <fs_mgr_flags>
 system                                                  /system                ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 system_ext                                              /system_ext            ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
-/dev/block/mapper/system                                /system_image          emmc    ro,barrier=1,discard                                 wait,logical,first_stage_mount,flashimg=1
+/dev/block/mapper/system                                /system_image          emmc    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 product                                                 /product               ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 vendor                                                  /vendor                ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 odm                                                     /odm                   ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount

--- a/recovery/root/system/etc/twrp.fstab
+++ b/recovery/root/system/etc/twrp.fstab
@@ -9,7 +9,7 @@ vendor		/vendor		ext4		display="Vendor";logical
 product		/product	ext4		display="Product";logical
 odm		/odm		ext4		display="Odm";logical
 
-/system_image     emmc     /dev/block/mapper/system                         flags=display="System Image";backup=0;flashing=1
+/system_image     emmc     /dev/block/mapper/system                         flags=display="System Image";backup=0;flashimg=1
 /cache		  ext4	   /dev/block/bootdevice/by-name/cache	
 /logfs            vfat     /dev/block/bootdevice/by-name/logfs              flags=display="logfs"
 /boot		  emmc	   /dev/block/bootdevice/by-name/boot
@@ -26,7 +26,7 @@ odm		/odm		ext4		display="Odm";logical
 /dsp		  emmc	   /dev/block/bootdevice/by-name/dsp		    flags=backup=1;subpartitionof=/modem
 /dsp_image        emmc     /dev/block/bootdevice/by-name/dsp                flags=display="dsp";flashimg=1
 /efs1		  emmc	   /dev/block/bootdevice/by-name/modemst1	    flags=backup=1;display="EFS"
-/efs2		  emmc	 . /dev/block/bootdevice/by-name/modemst2           flags=backup=1;subpartitionof=/efs1
+/efs2		  emmc	   /dev/block/bootdevice/by-name/modemst2           flags=backup=1;subpartitionof=/efs1
 /efsc		  emmc	   /dev/block/bootdevice/by-name/fsc		    flags=backup=1;subpartitionof=/efs1
 /efsg		  emmc	   /dev/block/bootdevice/by-name/fsg		    flags=backup=1;subpartitionof=/efs1
 /vbmeta		  emmc	   /dev/block/bootdevice/by-name/vbmeta		    flags=display="Vbmeta";backup=1;flashimg=1

--- a/recovery/root/system/etc/twrp.fstab
+++ b/recovery/root/system/etc/twrp.fstab
@@ -2,56 +2,57 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-# mount 		point  		fstype  	device                             device2                flags
+# mount 	point  		fstype  	device                             device2                flags
 system		/system		ext4		logical
 system_ext	/system_ext	ext4		logical
 vendor		/vendor		ext4		display="Vendor";logical
-product		/product		ext4		display="Product";logical
-odm			/odm			ext4		display="Odm";logical
+product		/product	ext4		display="Product";logical
+odm		/odm		ext4		display="Odm";logical
 
-/cache				ext4		/dev/block/bootdevice/by-name/cache	
-/logfs            vfat     /dev/block/bootdevice/by-name/logfs        flags=display="logfs"
-/boot					emmc		/dev/block/bootdevice/by-name/boot
-/super				emmc     /dev/block/bootdevice/by-name/super		    flags=display="Super";backup=1;flashimg=1
-/metadata			ext4		/dev/block/by-name/metadata     flags=display="Metadata";backup=1
-/metadata_image   emmc     /dev/block/by-name/metadata     flags=display="metadata";flashimg=1
-/data   				f2fs     /dev/block/bootdevice/by-name/userdata 	 flags=fileencryption=ice;wrappedkey;keydirectory=/metadata/vold/metadata_encryption
-/recovery			emmc     /dev/block/bootdevice/by-name/recovery     flags=display="Recovery";backup=1;flashimg=1
-/firmware			vfat		/dev/block/bootdevice/by-name/modem			 flags=display="Firmware";mounttodecrypt;fsflags=ro
-/firmware_image   emmc     /dev/block/bootdevice/by-name/modem        flags=display="Firmware";flashimg=1;backup=1
-/misc					emmc		/dev/block/bootdevice/by-name/misc
-/modem				emmc		/dev/block/bootdevice/by-name/modem			 flags=backup=1;display="Modem"
-/bluetooth			emmc		/dev/block/bootdevice/by-name/bluetooth	 flags=backup=1;subpartitionof=/modem
-/dsp					emmc		/dev/block/bootdevice/by-name/dsp			 flags=backup=1;subpartitionof=/modem
-/dsp_image        emmc     /dev/block/bootdevice/by-name/dsp          flags=display="dsp";flashimg=1
-/efs1					emmc		/dev/block/bootdevice/by-name/modemst1	 	 flags=backup=1;display="EFS"
-/efs2					emmc		/dev/block/bootdevice/by-name/modemst2		 flags=backup=1;subpartitionof=/efs1
-/efsc					emmc		/dev/block/bootdevice/by-name/fsc			 flags=backup=1;subpartitionof=/efs1
-/efsg					emmc		/dev/block/bootdevice/by-name/fsg			 flags=backup=1;subpartitionof=/efs1
-/vbmeta				emmc		/dev/block/bootdevice/by-name/vbmeta		 flags=display="Vbmeta";backup=1;flashimg=1
-/vbmeta_system		emmc		/dev/block/bootdevice/by-name/vbmeta_system flags=display="Vbmeta system";backup=1;flashimg=1
-/exaid				emmc		/dev/block/bootdevice/by-name/exaid			 flags=display="Exaid";backup=1;flashimg=1
-/cust             ext4     /dev/block/bootdevice/by-name/cust         flags=display="cust";backup=1
-/cust_image       emmc     /dev/block/bootdevice/by-name/cust         flags=display="cust";flashimg=1
-/logfs            vfat     /dev/block/bootdevice/by-name/logfs        flags=display="logfs";backup=1
-/spunvm           vfat     /dev/block/bootdevice/by-name/spunvm       flags=display="spunvm";backup=1
-/splash           emmc     /dev/block/bootdevice/by-name/splash       flags=display="splash";backup=1;flashimg=1
-/logo             emmc     /dev/block/bootdevice/by-name/logo         flags=display="logo";backup=1;flashimg=1
-/tz               emmc     /dev/block/bootdevice/by-name/tz           flags=display="tz";backup=1;flashimg=1
+/system_image     emmc     /dev/block/mapper/system                         flags=display="System Image";backup=0;flashing=1
+/cache		  ext4	   /dev/block/bootdevice/by-name/cache	
+/logfs            vfat     /dev/block/bootdevice/by-name/logfs              flags=display="logfs"
+/boot		  emmc	   /dev/block/bootdevice/by-name/boot
+/super		  emmc     /dev/block/bootdevice/by-name/super		    flags=display="Super";backup=1;flashimg=1
+/metadata	  ext4	   /dev/block/by-name/metadata                      flags=display="Metadata";backup=1
+/metadata_image   emmc     /dev/block/by-name/metadata                      flags=display="metadata";flashimg=1
+/data   	  f2fs     /dev/block/bootdevice/by-name/userdata 	    flags=fileencryption=ice;wrappedkey;keydirectory=/metadata/vold/metadata_encryption
+/recovery	  emmc     /dev/block/bootdevice/by-name/recovery           flags=display="Recovery";backup=1;flashimg=1
+/firmware	  vfat	   /dev/block/bootdevice/by-name/modem		    flags=display="Firmware";mounttodecrypt;fsflags=ro
+/firmware_image   emmc     /dev/block/bootdevice/by-name/modem              flags=display="Firmware";flashimg=1;backup=1
+/misc		  emmc	   /dev/block/bootdevice/by-name/misc
+/modem		  emmc	   /dev/block/bootdevice/by-name/modem		    flags=backup=1;display="Modem"
+/bluetooth	  emmc     /dev/block/bootdevice/by-name/bluetooth	    flags=backup=1;subpartitionof=/modem
+/dsp		  emmc	   /dev/block/bootdevice/by-name/dsp		    flags=backup=1;subpartitionof=/modem
+/dsp_image        emmc     /dev/block/bootdevice/by-name/dsp                flags=display="dsp";flashimg=1
+/efs1		  emmc	   /dev/block/bootdevice/by-name/modemst1	    flags=backup=1;display="EFS"
+/efs2		  emmc	 . /dev/block/bootdevice/by-name/modemst2           flags=backup=1;subpartitionof=/efs1
+/efsc		  emmc	   /dev/block/bootdevice/by-name/fsc		    flags=backup=1;subpartitionof=/efs1
+/efsg		  emmc	   /dev/block/bootdevice/by-name/fsg		    flags=backup=1;subpartitionof=/efs1
+/vbmeta		  emmc	   /dev/block/bootdevice/by-name/vbmeta		    flags=display="Vbmeta";backup=1;flashimg=1
+/vbmeta_system	  emmc	   /dev/block/bootdevice/by-name/vbmeta_system      flags=display="Vbmeta system";backup=1;flashimg=1
+/exaid		  emmc	   /dev/block/bootdevice/by-name/exaid		    flags=display="Exaid";backup=1;flashimg=1
+/cust             ext4     /dev/block/bootdevice/by-name/cust               flags=display="cust";backup=1
+/cust_image       emmc     /dev/block/bootdevice/by-name/cust               flags=display="cust";flashimg=1
+/logfs            vfat     /dev/block/bootdevice/by-name/logfs              flags=display="logfs";backup=1
+/spunvm           vfat     /dev/block/bootdevice/by-name/spunvm             flags=display="spunvm";backup=1
+/splash           emmc     /dev/block/bootdevice/by-name/splash             flags=display="splash";backup=1;flashimg=1
+/logo             emmc     /dev/block/bootdevice/by-name/logo               flags=display="logo";backup=1;flashimg=1
+/tz               emmc     /dev/block/bootdevice/by-name/tz                 flags=display="tz";backup=1;flashimg=1
 /keystore         emmc     /dev/block/bootdevice/by-name/keystore
 /ssd              emmc     /dev/block/bootdevice/by-name/ssd
 /frp              emmc     /dev/block/bootdevice/by-name/frp
 /ddr              emmc     /dev/block/bootdevice/by-name/ddr
 /devinfo          emmc     /dev/block/bootdevice/by-name/devinfo
 /fsc              emmc     /dev/block/bootdevice/by-name/fsc
-/abl              emmc     /dev/block/bootdevice/by-name/abl          flags=display="abl";backup=1;flashimg=1
-#/msadp            emmc     /dev/block/bootdevice/by-name/msadp        flags=display="msadp";backup=1;flashimg=1
-#/apdp             emmc     /dev/block/bootdevice/by-name/apdp         flags=display="apdp";backup=1;flashimg=1
-/cmnlib64         emmc     /dev/block/bootdevice/by-name/cmnlib64     flags=display="cmnlib64";backup=1;flashimg=1
-/cmnlib           emmc     /dev/block/bootdevice/by-name/cmnlib       flags=display="cmnlib";backup=1;flashimg=1
-/keymaster        emmc     /dev/block/bootdevice/by-name/keymaster    flags=display="keymaster";backup=1;flashimg=1
-#/hyp              emmc     /dev/block/bootdevice/by-name/hyp          flags=display="hyp";backup=1;flashimg=1
-#/devcfg           emmc     /dev/block/bootdevice/by-name/devcfg       flags=display="devcfg";backup=1;flashimg=1
+/abl              emmc     /dev/block/bootdevice/by-name/abl                flags=display="abl";backup=1;flashimg=1
+#/msadp           emmc     /dev/block/bootdevice/by-name/msadp              flags=display="msadp";backup=1;flashimg=1
+#/apdp            emmc     /dev/block/bootdevice/by-name/apdp               flags=display="apdp";backup=1;flashimg=1
+/cmnlib64         emmc     /dev/block/bootdevice/by-name/cmnlib64           flags=display="cmnlib64";backup=1;flashimg=1
+/cmnlib           emmc     /dev/block/bootdevice/by-name/cmnlib             flags=display="cmnlib";backup=1;flashimg=1
+/keymaster        emmc     /dev/block/bootdevice/by-name/keymaster          flags=display="keymaster";backup=1;flashimg=1
+#/hyp             emmc     /dev/block/bootdevice/by-name/hyp                flags=display="hyp";backup=1;flashimg=1
+#/devcfg          emmc     /dev/block/bootdevice/by-name/devcfg             flags=display="devcfg";backup=1;flashimg=1
 # Removable storage
-/usb-otg				vfat     /dev/block/sdg1		/dev/block/sdg		  	 flags=fsflags=utf8;storage;wipeingui;removable
+/usb-otg	  vfat     /dev/block/sdg1		/dev/block/sdg	    flags=fsflags=utf8;storage;wipeingui;removable
 

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -86,8 +86,5 @@ if [ "$1" = "$FDEVICE" -o "$FOX_BUILD_DEVICE" = "$FDEVICE" ]; then
    	   export | grep "TARGET_" >> $FOX_BUILD_LOG_FILE
   	   export | grep "TW_" >> $FOX_BUILD_LOG_FILE
  	fi
-
-	add_lunch_combo omni_"$FDEVICE"-eng
-	add_lunch_combo omni_"$FDEVICE"-userdebug
 fi
 #


### PR DESCRIPTION
This will add the option to flash system images such as GSI directly without using fastbootd or special scripts.
Note :
 This will add the warning : 
Unable to update /system_image Logical partition 
To the console. 